### PR TITLE
Update gwk.sh

### DIFF
--- a/gwk.sh
+++ b/gwk.sh
@@ -617,7 +617,7 @@ do_execute() {
 		return
 	fi
 	clear 
-	local tmpfile="/tmp/$(basename $0).$$.tmp"
+	local tmpfile="$(basename $0).$$.tmp"
 	print_signature
 	echo -e "Try to rlogin to ${yellow}$hostname_filter${reset} as ${magenta}$user${reset} ..."
 	echo 
@@ -639,13 +639,14 @@ good_bye(){
 	echo -e "${reset}${red}Happy Hacking!${reset}"
 	echo 
 	stty echo 
+	rm ~/gwk.sh.*.tmp &> /dev/null
 	exit 0;
 }
  
 #==============================================================================
 # Initialize
 #==============================================================================
-exec_kinit
+#exec_kinit
 init_host_list
 trap good_bye INT # trap ctrl+c
  


### PR DESCRIPTION
1. 보안상 이슈로 kerberos init 코드 삭제(실행 전에 kinit 별도로 1회 수행하면 일정 시간이내 가능합니다.)
2. /tmp/ 로 tmp파일이 생성되어 disk 이슈가 발생하는 케이스 수정
3. local에 만들어진 tmp 파일 삭제